### PR TITLE
feat: 硬件信息显示的排版优化为单行

### DIFF
--- a/Models/ToolItem.cs
+++ b/Models/ToolItem.cs
@@ -201,7 +201,7 @@ public sealed class ArchVariant
     public required string Arch { get; init; }
 }
 
-public sealed class ArchOption : INotifyPropertyChanged
+public sealed class ArchOption
 {
     public required string Name { get; init; }
     public required string Path { get; init; }
@@ -210,6 +210,4 @@ public sealed class ArchOption : INotifyPropertyChanged
     public string DisplayText => string.IsNullOrEmpty(Arch) ? "默认" : Arch;
 
     public override string ToString() => DisplayText;
-
-    public event PropertyChangedEventHandler? PropertyChanged;
 }

--- a/Pages/ConfigManagerDialog.xaml.cs
+++ b/Pages/ConfigManagerDialog.xaml.cs
@@ -300,7 +300,7 @@ public sealed partial class ConfigManagerDialog : ContentDialog
             var exePath = Environment.ProcessPath;
             if (string.IsNullOrEmpty(exePath)) return;
             System.Diagnostics.Process.Start(exePath);
-            App.MainWindow.Close();
+            App.MainWindow?.Close();
         }
         catch { }
     }

--- a/Pages/HardwarePage.xaml
+++ b/Pages/HardwarePage.xaml
@@ -199,10 +199,7 @@
             VerticalAlignment="Stretch"
             IsHitTestVisible="False" />
 
-        <Viewbox
-            x:Name="ContentScaler"
-            Stretch="Uniform"
-            StretchDirection="DownOnly">
+        <Border x:Name="RootHost">
             <Grid
                 x:Name="LayoutRoot"
                 Width="1100"
@@ -356,6 +353,8 @@
                                 <TextBlock FontSize="15" Opacity="0.68" Text="运行时间" />
                                 <TextBlock
                                     x:Name="UptimeText"
+                                    Width="220"
+                                    HorizontalAlignment="Left"
                                     FontSize="20"
                                     FontWeight="SemiBold"
                                     TextWrapping="Wrap" />
@@ -450,7 +449,7 @@
                     </Border>
                 </StackPanel>
             </Grid>
-        </Viewbox>
+        </Border>
 
         <ProgressRing
             x:Name="LoadingRing"

--- a/Pages/HardwarePage.xaml.cs
+++ b/Pages/HardwarePage.xaml.cs
@@ -37,9 +37,12 @@ public sealed partial class HardwarePage : Page
 
     private void OnSettingChanged(string key)
     {
-        if (key == "UseCpuzDataSource")
+        if (key == "UseCpuzDataSource" || key == "CompactModeEnabled")
         {
-            _ = LoadHardwareInfoAsync();
+            // 简洁模式切换时重置布局容器缓存，确保 UpdateLayoutStructure 能强制重建
+            if (key == "CompactModeEnabled")
+                _currentLayoutIsCompact = null;
+            _ = LoadHardwareInfoAsync(forceRefresh: true);
         }
     }
 
@@ -215,6 +218,9 @@ public sealed partial class HardwarePage : Page
 
     private void ApplySections(IReadOnlyList<HardwareInfoSection> sections)
     {
+        UpdateLayoutStructure();
+
+
         var summary = sections[0].Items;
         var system = sections[1].Items;
         var details = sections[2].Items;
@@ -598,5 +604,60 @@ public sealed partial class HardwarePage : Page
             if (result is not null) return result;
         }
         return null;
+    }
+
+    private bool? _currentLayoutIsCompact;
+
+    private void UpdateLayoutStructure()
+    {
+        var isCompact = AppSettings.GetBool("CompactModeEnabled", false);
+        if (_currentLayoutIsCompact == isCompact) return;
+        _currentLayoutIsCompact = isCompact;
+
+        if (LayoutRoot.Parent is Panel parentPanel)
+        {
+            parentPanel.Children.Remove(LayoutRoot);
+        }
+        else if (LayoutRoot.Parent is Border parentBorder)
+        {
+            parentBorder.Child = null;
+        }
+        else if (LayoutRoot.Parent is ScrollViewer parentScroll)
+        {
+            parentScroll.Content = null;
+        }
+        else if (LayoutRoot.Parent is Viewbox parentViewbox)
+        {
+            parentViewbox.Child = null;
+        }
+
+        if (isCompact)
+        {
+            LayoutRoot.Width = double.NaN;
+            LayoutRoot.MaxWidth = 1100;
+            LayoutRoot.HorizontalAlignment = HorizontalAlignment.Center;
+
+            var scroll = new ScrollViewer
+            {
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+                Content = LayoutRoot
+            };
+            RootHost.Child = scroll;
+        }
+        else
+        {
+            LayoutRoot.Width = 1100;
+            LayoutRoot.MaxWidth = double.PositiveInfinity;
+            LayoutRoot.HorizontalAlignment = HorizontalAlignment.Stretch;
+
+            var viewbox = new Viewbox
+            {
+                Stretch = Stretch.Uniform,
+                StretchDirection = StretchDirection.DownOnly,
+                Child = LayoutRoot
+            };
+            RootHost.Child = viewbox;
+        }
     }
 }

--- a/Pages/LiteMonitorPage.xaml.cs
+++ b/Pages/LiteMonitorPage.xaml.cs
@@ -546,8 +546,11 @@ public sealed partial class LiteMonitorPage : Page
 
         try
         {
-            var mainPos = App.MainWindow.AppWindow.Position;
-            window.AppWindow.Move(new PointInt32(mainPos.X + 10, mainPos.Y + 10));
+            if (App.MainWindow != null)
+            {
+                var mainPos = App.MainWindow.AppWindow.Position;
+                window.AppWindow.Move(new PointInt32(mainPos.X + 10, mainPos.Y + 10));
+            }
         }
         catch { }
 

--- a/Pages/SettingsPage.xaml.cs
+++ b/Pages/SettingsPage.xaml.cs
@@ -387,6 +387,8 @@ public sealed partial class SettingsPage : Page
     {
         if (_compactModeInitializing) return;
         CompactModeService.SetCompactModeEnabled(CompactModeToggle.IsOn);
+        // 简洁模式影响硬件信息的拼接分隔符，需令缓存失效
+        HardwareInfoService.InvalidateCache();
     }
 
     private void InitCompactModeToggle()

--- a/Services/BuiltinTools/DiskSpaceAnalyzerTool.cs
+++ b/Services/BuiltinTools/DiskSpaceAnalyzerTool.cs
@@ -381,7 +381,6 @@ file sealed class AnalyzerPage : Page
         }
     }
 
-    private volatile bool _scanning;
     private volatile int _scanDirty;
 
     private async Task ScanAsync(string path, bool keepNav = false)
@@ -395,7 +394,6 @@ file sealed class AnalyzerPage : Page
         if (_cv != null) _cv.Children.Clear();
         _hoveredNode = null;
         _pBytes = 0; _pItems = 0;
-        _scanning = true;
         _scanDirty = 0;
 
         GetDiskInfo(path);
@@ -426,14 +424,12 @@ file sealed class AnalyzerPage : Page
         {
             renderTimer.Stop();
             if (_pb != null) _pb.Visibility = Visibility.Collapsed;
-            _scanning = false;
             if (_st != null) _st.Text = "扫描已取消";
             return;
         }
         catch { renderTimer.Stop(); return; }
 
         renderTimer.Stop();
-        _scanning = false;
         node.Children.Sort((a, b) => b.Size.CompareTo(a.Size));
         if (_pb != null) _pb.Visibility = Visibility.Collapsed;
         SyncUi();

--- a/Services/HardwareInfoService.cs
+++ b/Services/HardwareInfoService.cs
@@ -63,6 +63,11 @@ public static class HardwareInfoService
     private static IReadOnlyList<HardwareInfoSection>? _cache;
     private static readonly object _lock = new();
 
+    private static string GetSeparator()
+    {
+        return AppSettings.GetBool("CompactModeEnabled", false) ? Environment.NewLine : " / ";
+    }
+
     public static bool HasCache
     {
         get { lock (_lock) { return _cache != null; } }
@@ -180,7 +185,7 @@ public static class HardwareInfoService
             var gpuItem = details.FirstOrDefault(it => it.Label == "显卡");
             if (gpuItem != null)
             {
-                var gpuLabel = string.Join(" / ", cpuz.Gpus
+                var gpuLabel = string.Join(GetSeparator(), cpuz.Gpus
                     .Where(g => !string.IsNullOrWhiteSpace(g.Name))
                     .Select(g =>
                     {
@@ -686,7 +691,7 @@ public static class HardwareInfoService
             })
             .Where(value => !string.IsNullOrWhiteSpace(value));
 
-        return string.Join(" / ", disks);
+        return string.Join(GetSeparator(), disks);
     }
 
     private static string FormatDisplays()
@@ -716,7 +721,7 @@ public static class HardwareInfoService
 
         if (monitorInfos.Count == 0) return "未知";
 
-        return string.Join(" / ", monitorInfos.Select(mi =>
+        return string.Join(GetSeparator(), monitorInfos.Select(mi =>
         {
             if (string.IsNullOrWhiteSpace(mi.Label) && string.IsNullOrWhiteSpace(mi.Resolution))
                 return "";
@@ -1203,7 +1208,7 @@ public static class HardwareInfoService
             .Where(value => !string.IsNullOrWhiteSpace(value))
             .Distinct();
 
-        return string.Join(" / ", names);
+        return string.Join(GetSeparator(), names);
     }
 
     private static ManagementBaseObject? First(string className)

--- a/TubaWinUi3.Compatible/Services/HardwareInfoService.cs
+++ b/TubaWinUi3.Compatible/Services/HardwareInfoService.cs
@@ -66,6 +66,11 @@ namespace TubaWinUi3.Compatible.Services
         private static IReadOnlyList<HardwareInfoSection> _cache;
         private static readonly object _lock = new object();
 
+        private static string GetSeparator()
+        {
+            return AppSettings.GetBool("CompactModeEnabled", false) ? Environment.NewLine : " / ";
+        }
+
         public static bool HasCache
         {
             get { lock (_lock) { return _cache != null; } }
@@ -469,7 +474,7 @@ namespace TubaWinUi3.Compatible.Services
                 })
                 .Where(value => !string.IsNullOrWhiteSpace(value));
 
-            return string.Join(" / ", disks);
+            return string.Join(GetSeparator(), disks);
         }
 
         private static string FormatDisplays()
@@ -501,7 +506,7 @@ namespace TubaWinUi3.Compatible.Services
                 if (string.IsNullOrWhiteSpace(bracket)) { parts.Add(label); continue; }
                 parts.Add(label + " [" + bracket + "]");
             }
-            return string.Join(" / ", parts);
+            return string.Join(GetSeparator(), parts);
         }
 
         private sealed class DisplayInfo
@@ -858,7 +863,7 @@ namespace TubaWinUi3.Compatible.Services
                 .Where(value => !string.IsNullOrWhiteSpace(value))
                 .Distinct();
 
-            return string.Join(" / ", names);
+            return string.Join(GetSeparator(), names);
         }
 
         private static ManagementBaseObject First(string className)


### PR DESCRIPTION
- 优化在多设备时排版拥挤的问题，且使其只在简洁模式生效。
- 其中UptimeText 采用固定宽度，消除秒数跳变导致的界面缩放抖动。
- 修复运行 dotnet run 时App.MainWindow 等空解引用及未使用的字段警告

**默认**
<img width="1520" height="823" alt="PixPin_2026-06-11_16-40-34" src="https://github.com/user-attachments/assets/24278292-cc75-480e-b356-8b7884510adc" />
**打开简洁模式**
<img width="1520" height="823" alt="PixPin_2026-06-11_16-12-18" src="https://github.com/user-attachments/assets/a84f5778-6e58-4292-bcc2-1db21ebf8f8d" />
**截图**
<img width="1031" height="1119" alt="88952ac4-9519-4bfc-918b-621ca6074133" src="https://github.com/user-attachments/assets/62b7dca7-7867-471c-9775-35921b3280a6" />
